### PR TITLE
[Fix] 랜딩 페이지에 있는 Header 컴포넌트 이벤트 코드 개선작업

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,11 +1,31 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
 import logo1 from '../assets/images/logo1.png';
 
 const Header = () => {
+  const headerRef = useRef(null);
+
+  const onScroll = () => {
+    headerRef.current.classList.toggle('sticky', window.scrollY > 0);
+  };
+
+  useEffect(() => {
+    console.log(headerRef.current);
+    console.log(headerRef);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [headerRef]);
+  // const onScroll = () => {
+  //   let header = document.querySelector('header');
+  //   header.classList.toggle('sticky', window.scrollY > 0);
+  // };
+  // useEffect(() => {
+  //   window.addEventListener('scroll', onScroll);
+  //   return () => window.removeEventListener('scroll', onScroll);
+  // }, []);
   return (
-    <header>
+    <header ref={headerRef}>
       <Link to="/" className="logo1">
         <img className="logo-img" src={logo1} alt="logo-image" />
       </Link>

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
 import Header from '../components/Header';
 import SearchBanner from '../components/SearchBanner';
@@ -7,14 +7,14 @@ import IntroDesc from '../components/IntroDesc';
 import Footer from '../components/Footer';
 
 const LandingPage = () => {
-  const onScroll = () => {
-    let header = document.querySelector('header');
-    header.classList.toggle('sticky', window.scrollY > 0);
-  };
-  useEffect(() => {
-    window.addEventListener('scroll', onScroll);
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
+  // const onScroll = () => {
+  //   let header = document.querySelector('header');
+  //   header.classList.toggle('sticky', window.scrollY > 0);
+  // };
+  // useEffect(() => {
+  //   window.addEventListener('scroll', onScroll);
+  //   return () => window.removeEventListener('scroll', onScroll);
+  // }, []);
 
   return (
     <div className="wrapper">


### PR DESCRIPTION
- Main LandingPage 에서 scroll 시 기존 Header 부분 CSS 변경이 됨.
- 하지만 로그인 페이지 이동 시 Dom 요소 직접 선택으로 인해 classList is
  null 이라는 오류가 뜬다.
- React 에서는 DOM 요소를 직접 쓰면 안되므로 useRef, useEffect 를
  사용했다.
- 성공적인 리팩토링 완료, 이제 화면 전환시 더이상 에러를 볼 수 없다.