### PR TITLE
[Fix] 응답 헤더에 있는 Refresh-Token 읽어들여서 로컬스토리지에 저장완료.

### DIFF
--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -31,9 +31,13 @@ const SignIn = () => {
     dispatch(signinUser(body))
       .then((res) => {
         console.log(res);
-        console.log(res.payload.accessToken);
-        let tokenData = res.payload.accessToken;
+        console.log(res.payload.data.accessToken);
+        console.log('리프레시토큰!', res.payload.headers['refresh-token']);
+        let tokenData = res.payload.data.accessToken;
         localStorage.setItem('CC_Token', tokenData);
+
+        let refreshTokenData = res.payload.headers['refresh-token'];
+        localStorage.setItem('RF_Token', refreshTokenData);
         history.push('/mypage');
       })
       .catch((err) => {

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -10,7 +10,8 @@ export const request = (method, url, data) => {
     method,
     url: DOMAIN + url,
     data,
-  }).then((res) => res.data);
+  }).then((res) => res);
+  // .then((res) => res.data);
   // .catch((err) => {
   //   console.log(err);
   //   return err.response;


### PR DESCRIPTION
- 서버측 응답 return res.set("Refresh-Token", refreshToken) 코드 다음에
  추가한 코드
- .set("Access-Control-Expose-Headers", "Refresh-Token")
- 이렇게 하면 클라이언트에서 응답 헤더에 보낸 refreshToken 을 읽어들일
  수 있다!
- 마찬가지로 로컬 스토리지에 저장 완료하였음.